### PR TITLE
HTTP range fix

### DIFF
--- a/lib/node-sftp-s3.js
+++ b/lib/node-sftp-s3.js
@@ -224,7 +224,7 @@ class SFTPS3Server extends EventEmitter {
 
               this.s3.getObject({
                  Key: state.fullname,
-                 Range: `bytes=${offset}-${offset+length-1}/${state.size}`
+                 Range: `bytes=${offset}-${offset+length-1}`
               }, function(err, data) {
                 if(err || data.Body.length === 0)
                   return sftpStream.status(reqid, STATUS_CODE.FAILURE);
@@ -597,4 +597,3 @@ class SFTPS3Server extends EventEmitter {
 }
 
 module.exports = SFTPS3Server;
-

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash": "^4.14.1",
     "mocha": "^3.0.2",
     "nyc": "^10.2.0",
-    "range-parser": "^1.2.0",
+    "http-range": "^1.0.0",
     "sinon": "^1.17.5",
     "sinon-chai": "2.8.0"
   }

--- a/test/s3stub.js
+++ b/test/s3stub.js
@@ -1,6 +1,6 @@
 'use strict';
 var _ = require('lodash');
-var parseRange = require('range-parser');
+var Range = require('http-range').Range;
 
 class S3Stub {
   constructor(params) {
@@ -92,8 +92,8 @@ class S3Stub {
     
     var data = obj.data;
     if(range) {
-      range = parseRange(data.length, range)[0];
-      data = data.slice(range.start, range.end + 1);
+      var r = Range.prototype.parse(range)._ranges[0]._range;
+      data = data.slice(r[0], r[1] + 1);
     }
 
     process.nextTick(() => cb(null, { Body: data, Size: data.length, LastModified: obj.LastModified }));


### PR DESCRIPTION
Fixed the HTTP range syntax that prevents to download files larger than the client buffer (usually 32KB). Thanks!

Example froon AWS doc: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html
```
GET /example-object HTTP/1.1
Host: example-bucket.s3.amazonaws.com
x-amz-date: Fri, 28 Jan 2011 21:32:02 GMT
Range: bytes=0-9
Authorization: AWS AKIAIOSFODNN7EXAMPLE:Yxg83MZaEgh3OZ3l0rLo5RTX11o=
Sample Response with Specified Range of the Object Bytes
```