### PR TITLE
Handle REALPATH ""

### DIFF
--- a/lib/node-sftp-s3.js
+++ b/lib/node-sftp-s3.js
@@ -368,7 +368,7 @@ class SFTPS3Server extends EventEmitter {
                   realObj.IsDir = true;
                 }
 
-                if(!realObj && p === '/') {
+                if(!realObj && p === '/.') {
                   this._log(util.format('listing empty root directory %s', p));
                   realObj = {
                     IsDir: true,

--- a/lib/node-sftp-s3.js
+++ b/lib/node-sftp-s3.js
@@ -368,7 +368,7 @@ class SFTPS3Server extends EventEmitter {
                   realObj.IsDir = true;
                 }
 
-                if(!realObj && p === '/.') {
+                if(!realObj && (p === '/' || p === '/.')) {
                   this._log(util.format('listing empty root directory %s', p));
                   realObj = {
                     IsDir: true,


### PR DESCRIPTION
REALPATH / is handled but REALPATH "" is not.  This change makes either request return the root directory's REALPATH.