### PR TITLE
Adds support for stat/lstat on a directory

### DIFF
--- a/lib/node-sftp-s3.js
+++ b/lib/node-sftp-s3.js
@@ -514,23 +514,44 @@ class SFTPS3Server extends EventEmitter {
                 if(err)
                   return sftpStream.status(reqid, STATUS_CODE.FAILURE);
 
-                var f = _.find(data.Contents, { Key: fullname }); //exact filename match
-                if(!f)
-                  return sftpStream.status(reqid, STATUS_CODE.NO_SUCH_FILE);
+                var exactMatch = _.find(data.Contents, { Key: fullname });    //exact filename match
+                if(exactMatch) {
+                  var mode = constants.S_IFREG;   // regular file
+                  mode |= constants.S_IRWXU;      // read, write, execute for user
+                  mode |= constants.S_IRWXG;      // read, write, execute for group
+                  mode |= constants.S_IRWXO;      // read, write, execute for other
 
-                var mode = constants.S_IFREG;
-                mode |= constants.S_IRWXU; // read, write, execute for user
-                mode |= constants.S_IRWXG; // read, write, execute for group
-                mode |= constants.S_IRWXO; // read, write, execute for other
+                  sftpStream.attrs(reqid, {
+                    mode: mode,
+                    uid: 0,
+                    gid: 0,
+                    size: exactMatch.Size,
+                    atime: exactMatch.LastModified,
+                    mtime: exactMatch.LastModified
+                  });
+                  return;
+                }
+                  
+                var directoryMatch = _.find(data.Contents, { Key: fullname + '/.dir' });    //directory match
+                if(directoryMatch) {
+                  var mode = constants.S_IFDIR;   // directory
+                  mode |= constants.S_IRWXU;      // read, write, execute for user
+                  mode |= constants.S_IRWXG;      // read, write, execute for group
+                  mode |= constants.S_IRWXO;      // read, write, execute for other
 
-                sftpStream.attrs(reqid, {
-                  mode: mode,
-                  uid: 0,
-                  gid: 0,
-                  size: f.Size,
-                  atime: f.LastModified,
-                  mtime: f.LastModified
-                });
+                  sftpStream.attrs(reqid, {
+                    mode: mode,
+                    uid: 0,
+                    gid: 0,
+                    size: 1,
+                    atime: directoryMatch.LastModified,
+                    mtime: directoryMatch.LastModified
+                  });
+                  return;
+                }
+                  
+                //No matches
+                return sftpStream.status(reqid, STATUS_CODE.NO_SUCH_FILE);
               });
             }
           });


### PR DESCRIPTION
Currently stat/lstat only work for exactly-matched files.  This adds support for calling stat on directories as well.