### PR TITLE
rename path to / when entering with /. to avoid listing errors in some…

### DIFF
--- a/lib/node-sftp-s3.js
+++ b/lib/node-sftp-s3.js
@@ -375,6 +375,7 @@ class SFTPS3Server extends EventEmitter {
                     LastModified: new Date(),
                     Size: 0
                   };
+                  p = '/';
                 }
 
                 if(!realObj) {


### PR DESCRIPTION
rename path to / when entering with /. to avoid listing errors in some SFTP clients like forklift. 