### PR TITLE
Fix bad this reference breaking tests

### DIFF
--- a/lib/node-sftp-s3.js
+++ b/lib/node-sftp-s3.js
@@ -244,7 +244,7 @@ class SFTPS3Server extends EventEmitter {
               this.s3.getObject({
                  Key: state.fullname,
                  Range: `bytes=${offset}-${offset+length-1}`
-              }, function(err, data) {
+              }, (err, data) => {
                 if(err || data.Body.length === 0) {
                   this._log(util.format('S3 error getting object %s: %s', state.fullname, err));
                   return sftpStream.status(reqid, STATUS_CODE.FAILURE);


### PR DESCRIPTION
Fix the bad `this` reference causing tests to fail and errors in production